### PR TITLE
Fix: Export BaseModelConfig from models.base package

### DIFF
--- a/src/krishi_sahayak/models/base/__init__.py
+++ b/src/krishi_sahayak/models/base/__init__.py
@@ -1,9 +1,9 @@
 """Base model class for KrishiSahayak.
 
-This module exports the single, canonical `BaseModel` which serves as the
-foundation for all models in the system.
+This module exports the single, canonical `BaseModel` and its configuration `BaseModelConfig`
+which serve as the foundation for all models in the system.
 """
 
-from .base import BaseModel
+from .base import BaseModel, BaseModelConfig
 
-__all__ = ["BaseModel"]
+__all__ = ["BaseModel", "BaseModelConfig"]


### PR DESCRIPTION
Ensures that `BaseModelConfig` is correctly exported from the `krishi_sahayak.models.base` package by adding it to the `__all__` list in `src/krishi_sahayak/models/base/__init__.py`.

This change is intended to resolve an `ImportError` for `StreamConfig` that was likely caused by an earlier failure in the import chain due to `BaseModelConfig` not being properly exposed. Other modules, such as `config.schemas`, depend on `BaseModelConfig` being importable from `krishi_sahayak.models.base`.